### PR TITLE
Adding Configurable Value for RolesClaim Name.

### DIFF
--- a/durablefunctionsmonitor.dotnetbackend/Common/Auth.cs
+++ b/durablefunctionsmonitor.dotnetbackend/Common/Auth.cs
@@ -31,7 +31,7 @@ namespace DurableFunctionsMonitor.DotNetBackend
         public const string PreferredUserNameClaim = "preferred_username";
 
         // Roles claim name
-        private const string RolesClaim = "roles";
+        private const string RolesClaim = ClaimTypes.Role;
 
         // If DFM_NONCE was passed as env variable, validates that the incoming request contains it. Throws UnauthorizedAccessException, if it doesn't.
         public static bool IsNonceSetAndValid(IHeaderDictionary headers)

--- a/durablefunctionsmonitor.dotnetbackend/Common/Auth.cs
+++ b/durablefunctionsmonitor.dotnetbackend/Common/Auth.cs
@@ -31,7 +31,7 @@ namespace DurableFunctionsMonitor.DotNetBackend
         public const string PreferredUserNameClaim = "preferred_username";
 
         // Roles claim name
-        private const string RolesClaim = ClaimTypes.Role;
+        public const string RolesClaim = "roles";
 
         // If DFM_NONCE was passed as env variable, validates that the incoming request contains it. Throws UnauthorizedAccessException, if it doesn't.
         public static bool IsNonceSetAndValid(IHeaderDictionary headers)
@@ -101,7 +101,7 @@ namespace DurableFunctionsMonitor.DotNetBackend
             // Also validating App Roles, if set
             if (DfmEndpoint.Settings.AllowedAppRoles != null)
             {
-                var roleClaims = principal.FindAll(RolesClaim);
+                var roleClaims = principal.FindAll(DfmEndpoint.Settings.RolesClaimName);
                 if (!roleClaims.Any(claim => DfmEndpoint.Settings.AllowedAppRoles.Contains(claim.Value)))
                 {
                     throw new UnauthorizedAccessException($"User {userNameClaim.Value} doesn't have any of roles mentioned in {EnvVariableNames.DFM_ALLOWED_APP_ROLES} config setting. Call is rejected");

--- a/durablefunctionsmonitor.dotnetbackend/Common/Globals.cs
+++ b/durablefunctionsmonitor.dotnetbackend/Common/Globals.cs
@@ -32,6 +32,7 @@ namespace DurableFunctionsMonitor.DotNetBackend
         public const string DFM_CLIENT_CONFIG = "DFM_CLIENT_CONFIG";
         public const string DFM_MODE = "DFM_MODE";
         public const string DFM_USERNAME_CLAIM_NAME = "DFM_USERNAME_CLAIM_NAME";
+        public const string DFM_ROLES_CLAIM_NAME = "DFM_ROLES_CLAIM_NAME";
         public const string DFM_ALTERNATIVE_CONNECTION_STRING_PREFIX = "DFM_ALTERNATIVE_CONNECTION_STRING_";
     }
 

--- a/durablefunctionsmonitor.dotnetbackend/Common/Setup.cs
+++ b/durablefunctionsmonitor.dotnetbackend/Common/Setup.cs
@@ -61,9 +61,16 @@ namespace DurableFunctionsMonitor.DotNetBackend
         /// </summary>
         public string UserNameClaimName { get; set; }
 
+        /// <summary>
+        /// Name of the claim (from ClaimsCredential) to be used as a role name.
+        /// Defaults to "roles"
+        /// </summary>
+        public string RolesClaimName { get; set; }
+
         public DfmSettings()
         {
             this.UserNameClaimName = Auth.PreferredUserNameClaim;
+            this.RolesClaimName = Auth.RolesClaim;
         }
     }
 
@@ -108,6 +115,7 @@ namespace DurableFunctionsMonitor.DotNetBackend
                 string dfmAllowedAppRoles = Environment.GetEnvironmentVariable(EnvVariableNames.DFM_ALLOWED_APP_ROLES);
                 string dfmMode = Environment.GetEnvironmentVariable(EnvVariableNames.DFM_MODE);
                 string dfmUserNameClaimName = Environment.GetEnvironmentVariable(EnvVariableNames.DFM_USERNAME_CLAIM_NAME);
+                string dfmRolesClaimName = Environment.GetEnvironmentVariable(EnvVariableNames.DFM_ROLES_CLAIM_NAME);
 
                 _settings = new DfmSettings()
                 {
@@ -117,7 +125,8 @@ namespace DurableFunctionsMonitor.DotNetBackend
                     Mode = dfmMode == DfmMode.ReadOnly.ToString() ? DfmMode.ReadOnly : DfmMode.Normal,
                     AllowedUserNames = dfmAllowedUserNames == null ? null : dfmAllowedUserNames.Split(','),
                     AllowedAppRoles = dfmAllowedAppRoles == null ? null : dfmAllowedAppRoles.Split(','),
-                    UserNameClaimName = string.IsNullOrEmpty(dfmUserNameClaimName) ? Auth.PreferredUserNameClaim : dfmUserNameClaimName
+                    UserNameClaimName = string.IsNullOrEmpty(dfmUserNameClaimName) ? Auth.PreferredUserNameClaim : dfmUserNameClaimName,
+                    RolesClaimName = string.IsNullOrEmpty(dfmRolesClaimName) ? Auth.RolesClaim : dfmRolesClaimName
                 };
             }
 

--- a/tests/durablefunctionsmonitor.dotnetbackend.tests/AuthTests.cs
+++ b/tests/durablefunctionsmonitor.dotnetbackend.tests/AuthTests.cs
@@ -344,7 +344,7 @@ namespace durablefunctionsmonitor.dotnetbackend.tests
 
             var principal = new ClaimsPrincipal(new ClaimsIdentity[] { new ClaimsIdentity( new Claim[] {
                 new Claim("preferred_username", userName),
-                new Claim(ClaimTypes.Role, roleName)
+                new Claim("roles", roleName)
             })});
 
             ICollection<SecurityKey> securityKeys = new SecurityKey[0];

--- a/tests/durablefunctionsmonitor.dotnetbackend.tests/AuthTests.cs
+++ b/tests/durablefunctionsmonitor.dotnetbackend.tests/AuthTests.cs
@@ -344,7 +344,7 @@ namespace durablefunctionsmonitor.dotnetbackend.tests
 
             var principal = new ClaimsPrincipal(new ClaimsIdentity[] { new ClaimsIdentity( new Claim[] {
                 new Claim("preferred_username", userName),
-                new Claim("roles", roleName)
+                new Claim(ClaimTypes.Role, roleName)
             })});
 
             ICollection<SecurityKey> securityKeys = new SecurityKey[0];


### PR DESCRIPTION
Change the string for RolesClaim to the enum used by System.Security.Claims assembly.  This enables the code in line 104 to find the claims in the token properly.