### PR TITLE
Update Core Tools warning

### DIFF
--- a/durablefunctionsmonitor-vscodeext/src/BackendProcess.ts
+++ b/durablefunctionsmonitor-vscodeext/src/BackendProcess.ts
@@ -172,6 +172,11 @@ export class BackendProcess {
     
                 this._eventualBinariesFolder = publishFolder;
             }
+
+            // check for func exe
+            if (!funcExePath){
+                reject('Ensure you have the latest Azure Functions Core Tools installed globally.');
+            }
             
             this._funcProcess = cp.spawn(funcExePath, ['start', '--port', portNr.toString(), '--csharp'], {
                 cwd: this._eventualBinariesFolder,
@@ -272,7 +277,7 @@ export class BackendProcess {
     }
 
     private async getFuncExePath(): Promise<string> {
-
+        
         if (!!BackendProcess._funcExePath) {
             return BackendProcess._funcExePath;
         }
@@ -362,8 +367,6 @@ export class BackendProcess {
             }
         }
 
-        // Defaulting to 'func' command, hopefully it will be properly resolved
-        BackendProcess._funcExePath = 'func';
-        return BackendProcess._funcExePath;
+        return "";
     }
 }

--- a/durablefunctionsmonitor-vscodeext/src/BackendProcess.ts
+++ b/durablefunctionsmonitor-vscodeext/src/BackendProcess.ts
@@ -12,6 +12,7 @@ import * as cp from 'child_process';
 import * as util from 'util';
 
 const execAsync = util.promisify(cp.exec);
+const { execSync } = require("child_process");
 
 import * as SharedConstants from './SharedConstants';
 import { Settings } from './Settings';
@@ -173,11 +174,13 @@ export class BackendProcess {
                 this._eventualBinariesFolder = publishFolder;
             }
 
-            // check for func exe
-            if (!funcExePath){
-                reject('Ensure you have the latest Azure Functions Core Tools installed globally.');
+            try {
+                const cmd = `"${funcExePath}" --version`;
+                execSync(cmd);
+            } catch (error) {
+                reject(`Azure Functions Core Tools not found. Ensure that you have the latest Azure Functions Core Tools installed globally.`);
             }
-            
+
             this._funcProcess = cp.spawn(funcExePath, ['start', '--port', portNr.toString(), '--csharp'], {
                 cwd: this._eventualBinariesFolder,
                 env: this.getEnvVariables()
@@ -367,6 +370,8 @@ export class BackendProcess {
             }
         }
 
-        return "";
+        // Defaulting to 'func' command, hopefully it will be properly resolved
+        BackendProcess._funcExePath = 'func';
+        return BackendProcess._funcExePath;
     }
 }

--- a/durablefunctionsmonitor-vscodeext/src/BackendProcess.ts
+++ b/durablefunctionsmonitor-vscodeext/src/BackendProcess.ts
@@ -89,6 +89,9 @@ export class BackendProcess {
     // Path to Functions host
     private static _funcExePath: string = '';
 
+    // True if Azure Functions Core Tools is installed
+    private static _coreToolsInstalled: boolean = false;
+
     // Prepares a set of environment variables for the backend process
     private getEnvVariables(): {} {
 
@@ -175,8 +178,11 @@ export class BackendProcess {
             }
 
             try {
-                const cmd = `"${funcExePath}" --version`;
-                execSync(cmd);
+                if (!BackendProcess._coreToolsInstalled){
+                    const cmd = `"${funcExePath}" --version`;
+                    execSync(cmd);
+                    BackendProcess._coreToolsInstalled = true;
+                }
             } catch (error) {
                 reject(`Azure Functions Core Tools not found. Ensure that you have the latest Azure Functions Core Tools installed globally.`);
             }

--- a/durablefunctionsmonitor.dotnetbackend/durablefunctionsmonitor.dotnetbackend.csproj
+++ b/durablefunctionsmonitor.dotnetbackend/durablefunctionsmonitor.dotnetbackend.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.7.1" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.11.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.8.0" />
     <PackageReference Include="Fluid.Core" Version="2.1.4" />
   </ItemGroup>


### PR DESCRIPTION
This PR helps alert customers that they don't have Azure Functions Core Tools installed earlier in setup. Right now, customers have to wait for the "Starting backend" task to timeout after 60 seconds before getting this message.