### PR TITLE
More on #45. Support for non-Azure hosting scenarios

### DIFF
--- a/durablefunctionsmonitor.dotnetbackend/Common/HttpHandlerBase.cs
+++ b/durablefunctionsmonitor.dotnetbackend/Common/HttpHandlerBase.cs
@@ -25,11 +25,11 @@ namespace DurableFunctionsMonitor.DotNetBackend
         }
 
         // Applies authN/authZ rules and handles incoming HTTP request. Also creates IDurableClient (when needed) and does error handling.
-        protected async Task<IActionResult> HandleAuthAndErrors(IDurableClient defaultDurableClient, HttpRequest req, string connName, string hubName, ILogger log, Func<IDurableClient, Task<IActionResult>> todo)
+        protected async Task<IActionResult> HandleAuthAndErrors(OperationKind kind, IDurableClient defaultDurableClient, HttpRequest req, string connName, string hubName, ILogger log, Func<IDurableClient, Task<IActionResult>> todo)
         {
             return await Globals.HandleErrors(req, log, async () => { 
 
-                await Auth.ValidateIdentityAsync(req.HttpContext.User, req.Headers, req.Cookies, Globals.CombineConnNameAndHubName(connName, hubName));
+                await Auth.ValidateIdentityAsync(req.HttpContext.User, req.Headers, req.Cookies, Globals.CombineConnNameAndHubName(connName, hubName), kind);
 
                 // For default storage connections using default durableClient, injected normally, as a parameter.
                 // Only using IDurableClientFactory for custom connections, just in case.

--- a/durablefunctionsmonitor.dotnetbackend/Functions/About.cs
+++ b/durablefunctionsmonitor.dotnetbackend/Functions/About.cs
@@ -25,7 +25,7 @@ namespace DurableFunctionsMonitor.DotNetBackend
             ILogger log
         )
         {
-            return req.HandleAuthAndErrors(connName, hubName, log, async () => {
+            return req.HandleAuthAndErrors(OperationKind.Read, connName, hubName, log, async () => {
 
                 string accountName = string.Empty;
 

--- a/durablefunctionsmonitor.dotnetbackend/Functions/CleanEntityStorage.cs
+++ b/durablefunctionsmonitor.dotnetbackend/Functions/CleanEntityStorage.cs
@@ -35,10 +35,8 @@ namespace DurableFunctionsMonitor.DotNetBackend
             string hubName,
             ILogger log)
         {
-            return this.HandleAuthAndErrors(defaultDurableClient, req, connName, hubName, log, async (durableClient) => {
+            return this.HandleAuthAndErrors(OperationKind.Write, defaultDurableClient, req, connName, hubName, log, async (durableClient) => {
              
-                Auth.ThrowIfInReadOnlyMode(req.HttpContext.User);
-
                 var request = JsonConvert.DeserializeObject<CleanEntityStorageRequest>(await req.ReadAsStringAsync());
 
                 var result = await durableClient.CleanEntityStorageAsync(request.removeEmptyEntities, request.releaseOrphanedLocks, CancellationToken.None);

--- a/durablefunctionsmonitor.dotnetbackend/Functions/DeleteTaskHub.cs
+++ b/durablefunctionsmonitor.dotnetbackend/Functions/DeleteTaskHub.cs
@@ -29,9 +29,7 @@ namespace DurableFunctionsMonitor.DotNetBackend
             ILogger log
         )
         {
-            return this.HandleAuthAndErrors(defaultDurableClient, req, connName, hubName, log, async (_) => {
-
-                Auth.ThrowIfInReadOnlyMode(req.HttpContext.User);
+            return this.HandleAuthAndErrors(OperationKind.Write, defaultDurableClient, req, connName, hubName, log, async (_) => {
 
                 string connectionString = Environment.GetEnvironmentVariable(Globals.GetFullConnectionStringEnvVariableName(connName));
 

--- a/durablefunctionsmonitor.dotnetbackend/Functions/FunctionMap.cs
+++ b/durablefunctionsmonitor.dotnetbackend/Functions/FunctionMap.cs
@@ -24,7 +24,7 @@ namespace DurableFunctionsMonitor.DotNetBackend
             ILogger log
         )
         {
-            return req.HandleAuthAndErrors(connName, hubName, log, async () => {
+            return req.HandleAuthAndErrors(OperationKind.Read, connName, hubName, log, async () => {
 
                 // The underlying Task never throws, so it's OK.
                 var functionMapsMap = await CustomTemplates.GetFunctionMapsAsync();

--- a/durablefunctionsmonitor.dotnetbackend/Functions/IdSuggestions.cs
+++ b/durablefunctionsmonitor.dotnetbackend/Functions/IdSuggestions.cs
@@ -29,7 +29,7 @@ namespace DurableFunctionsMonitor.DotNetBackend
             string prefix,
             ILogger log)
         {
-            return this.HandleAuthAndErrors(defaultDurableClient, req, connName, hubName, log, async (durableClient) => {
+            return this.HandleAuthAndErrors(OperationKind.Read, defaultDurableClient, req, connName, hubName, log, async (durableClient) => {
 
                 var response = await durableClient.ListInstancesAsync(new OrchestrationStatusQueryCondition()
                     {

--- a/durablefunctionsmonitor.dotnetbackend/Functions/Orchestration.cs
+++ b/durablefunctionsmonitor.dotnetbackend/Functions/Orchestration.cs
@@ -34,7 +34,7 @@ namespace DurableFunctionsMonitor.DotNetBackend
             string instanceId,
             ILogger log)
         {
-            return this.HandleAuthAndErrors(defaultDurableClient, req, connName, hubName, log, async (durableClient) => {
+            return this.HandleAuthAndErrors(OperationKind.Read, defaultDurableClient, req, connName, hubName, log, async (durableClient) => {
 
                 var status = await durableClient.GetStatusAsync(instanceId, false, false, true);
                 if (status == null)
@@ -59,7 +59,7 @@ namespace DurableFunctionsMonitor.DotNetBackend
             string instanceId,
             ILogger log)
         {
-            return this.HandleAuthAndErrors(defaultDurableClient, req, connName, hubName, log, async (durableClient) => {
+            return this.HandleAuthAndErrors(OperationKind.Read, defaultDurableClient, req, connName, hubName, log, async (durableClient) => {
 
                 var filterClause = new FilterClause(req.Query["$filter"]);
                 HistoryEvent[] history;
@@ -120,9 +120,7 @@ namespace DurableFunctionsMonitor.DotNetBackend
             string hubName,
             ILogger log)
         {
-            return this.HandleAuthAndErrors(defaultDurableClient, req, connName, hubName, log, async (durableClient) => {
-
-                Auth.ThrowIfInReadOnlyMode(req.HttpContext.User);
+            return this.HandleAuthAndErrors(OperationKind.Write, defaultDurableClient, req, connName, hubName, log, async (durableClient) => {
 
                 string bodyString = await req.ReadAsStringAsync();
                 dynamic body = JObject.Parse(bodyString);
@@ -153,9 +151,7 @@ namespace DurableFunctionsMonitor.DotNetBackend
             string action,
             ILogger log)
         {
-            return this.HandleAuthAndErrors(defaultDurableClient, req, connName, hubName, log, async (durableClient) => {
-
-                Auth.ThrowIfInReadOnlyMode(req.HttpContext.User);
+            return this.HandleAuthAndErrors(OperationKind.Write, defaultDurableClient, req, connName, hubName, log, async (durableClient) => {
 
                 string bodyString = await req.ReadAsStringAsync();
 
@@ -240,7 +236,7 @@ namespace DurableFunctionsMonitor.DotNetBackend
             string templateName,
             ILogger log)
         {
-            return this.HandleAuthAndErrors(defaultDurableClient, req, connName, hubName, log, async (durableClient) => {
+            return this.HandleAuthAndErrors(OperationKind.Read, defaultDurableClient, req, connName, hubName, log, async (durableClient) => {
 
                 var status = await GetInstanceStatusWithHistory(connName, hubName, instanceId, durableClient, log);
                 if (status == null)

--- a/durablefunctionsmonitor.dotnetbackend/Functions/Orchestrations.cs
+++ b/durablefunctionsmonitor.dotnetbackend/Functions/Orchestrations.cs
@@ -32,7 +32,7 @@ namespace DurableFunctionsMonitor.DotNetBackend
             string hubName,
             ILogger log)
         {
-            return this.HandleAuthAndErrors(defaultDurableClient, req, connName, hubName, log, async (durableClient) => {
+            return this.HandleAuthAndErrors(OperationKind.Read, defaultDurableClient, req, connName, hubName, log, async (durableClient) => {
 
                 var filterClause = new FilterClause(req.Query["$filter"]);
 

--- a/durablefunctionsmonitor.dotnetbackend/Functions/PurgeHistory.cs
+++ b/durablefunctionsmonitor.dotnetbackend/Functions/PurgeHistory.cs
@@ -39,9 +39,7 @@ namespace DurableFunctionsMonitor.DotNetBackend
             string hubName,
             ILogger log)
         {
-            return this.HandleAuthAndErrors(defaultDurableClient, req, connName, hubName, log, async (durableClient) => {
-
-                Auth.ThrowIfInReadOnlyMode(req.HttpContext.User);
+            return this.HandleAuthAndErrors(OperationKind.Write, defaultDurableClient, req, connName, hubName, log, async (durableClient) => {
 
                 // Important to deserialize time fields as strings, because otherwise time zone will appear to be local
                 var request = JsonConvert.DeserializeObject<PurgeHistoryRequest>(await req.ReadAsStringAsync());

--- a/durablefunctionsmonitor.dotnetbackend/Functions/TaskHubNames.cs
+++ b/durablefunctionsmonitor.dotnetbackend/Functions/TaskHubNames.cs
@@ -20,7 +20,7 @@ namespace DurableFunctionsMonitor.DotNetBackend
             ILogger log
         )
         {
-            return req.HandleAuthAndErrors(null, null, log, async () => {
+            return req.HandleAuthAndErrors(OperationKind.Read, null, null, log, async () => {
 
                 var hubNames = await Auth.GetAllowedTaskHubNamesAsync();
                 if (hubNames == null)

--- a/tests/durablefunctionsmonitor.dotnetbackend.tests/AuthTests.cs
+++ b/tests/durablefunctionsmonitor.dotnetbackend.tests/AuthTests.cs
@@ -93,6 +93,8 @@ namespace durablefunctionsmonitor.dotnetbackend.tests
 
                 await new IdSuggestions(null).DfmGetIdSuggestionsFunction(request, durableClientMoq.Object, "-", "TestHub", "abc", logMoq.Object),
 
+                await ManageConnection.DfmGetConnectionInfoFunction(request, "-", "TestHub", new Microsoft.Azure.WebJobs.ExecutionContext(), logMoq.Object),
+
                 await ManageConnection.DfmManageConnectionFunction(request, "-", "TestHub", new Microsoft.Azure.WebJobs.ExecutionContext(), logMoq.Object),
 
                 await new IdSuggestions(null).DfmGetIdSuggestionsFunction(request, durableClientMoq.Object, "-", "TestHub", "abc", logMoq.Object),

--- a/tests/durablefunctionsmonitor.dotnetbackend.tests/GlobalsTests.cs
+++ b/tests/durablefunctionsmonitor.dotnetbackend.tests/GlobalsTests.cs
@@ -48,7 +48,7 @@ namespace durablefunctionsmonitor.dotnetbackend.tests
 
             // Act
 
-            var res = await Globals.HandleAuthAndErrors(request, null, null, logMoq.Object, async () => {
+            var res = await Globals.HandleAuthAndErrors(request, OperationKind.Read, null, null, logMoq.Object, async () => {
                 return new OkResult();
             });
 
@@ -87,7 +87,7 @@ namespace durablefunctionsmonitor.dotnetbackend.tests
 
             // Act
 
-            var res = (BadRequestObjectResult) (await Globals.HandleAuthAndErrors(request, null, null, logMoq.Object, async () => {
+            var res = (BadRequestObjectResult) (await Globals.HandleAuthAndErrors(request, OperationKind.Read, null, null, logMoq.Object, async () => {
                 throw new MyTestException(myErrorMessage);
             }));
 


### PR DESCRIPTION
Outside of Azure ClientCredential doesn't come with request, and instead we have to validate the incoming access token and produce ClientCredential out of it ourselves.
This affects authorization logic for read-only app roles. Here is a fix to address that.