### PR TITLE
Update and fix configuration for Netherite sample

### DIFF
--- a/custom-backends/netherite/Dfm.Netherite.csproj
+++ b/custom-backends/netherite/Dfm.Netherite.csproj
@@ -1,17 +1,21 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+	<TargetFramework>net6.0</TargetFramework>
+	<AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.Netherite.AzureFunctions" Version="1.0.2" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.12" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.6.1" />
-    <PackageReference Include="durablefunctionsmonitor.dotnetbackend" Version="5.5.0" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Netherite.AzureFunctions" Version="1.3.1" />
+	<PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
+	<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.9.0" />
+	<PackageReference Include="durablefunctionsmonitor.dotnetbackend" Version="6.1.1" />  
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+	<None Update="local.settings.json">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+	</None>
   </ItemGroup>
 </Project>

--- a/custom-backends/netherite/README.md
+++ b/custom-backends/netherite/README.md
@@ -15,12 +15,9 @@ This is different than with Azure Storage provider or the Microsoft SQL provider
 {
   "IsEncrypted": false,
   "Values": {
-    "DFM_NONCE": "i_sure_know_what_i_am_doing_with_no_authentication",
+    "DFM_NONCE": "i_sure_know_what_i_am_doing",
     "AzureWebJobsStorage": "insert-azure-storage-connection-string-here",
     "EventHubsConnection": "insert-eventhubs-sas-connection-string-here"
-  },
-  "Host": {
-    "LocalHttpPort": 7072
   }
 }
 ```
@@ -30,7 +27,8 @@ If you prefer to no enter the connection strings into a file, you can omit the r
 
 4. Enter the Dfm.Netherite directory from a console, and enter `func start`
 
-5. Direct your browser to http://localhost:7072/. 
+5. If it does not open by itself, direct your browser to http://localhost:7072/. 
+   You can change this port and whether to open the browser in Prperties/launchSettings.json
 
 CAUTION: the configuration settings as above do not protect this endpoint.
 

--- a/custom-backends/netherite/host.json
+++ b/custom-backends/netherite/host.json
@@ -7,7 +7,8 @@
     "durableTask": {
       "hubName": "insert-task-hub-name-here",
       "storageProvider": {
-        "type": "netherite"
+        "type": "netherite",
+        "PartitionManagement": "ClientOnly"
       }
     }
   }


### PR DESCRIPTION
Based on a recent [discussion](https://github.com/microsoft/DurableFunctionsMonitor/discussions/90#discussioncomment-4991848) I took another look at this sample and found that it was outdated and missing some configuration settings.

I updated the package versions and configuration settings (and README instructions), and it now starts correctly.

However, there are still issues. For example, DF monitor presents a task hub selection menu which does not work with the Netherite backend (the task hub name is fixed in the configuration, and there is no such query available on the client so it cannot be supported). I think in the past the DF monitor would skip this menu since this never really was possible to do? Not sure if something changed. Maybe  @bachuv knows if something changed there. 