### PR TITLE
patch GH automation

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -1,94 +1,105 @@
-id: 
+id:
 name: GitOps.PullRequestIssueManagement
 description: GitOps.PullRequestIssueManagement primitive
-owner: 
+owner:
 resource: repository
 disabled: false
-where: 
+where:
 configuration:
   resourceManagementConfiguration:
     scheduledSearches:
-    - description: 
-      frequencies:
-      - hourly:
-          hour: 6
-      filters:
-      - isIssue
-      - isOpen
-      - hasLabel:
-          label: 'Needs: Author Feedback'
-      - hasLabel:
-          label: no-recent-activity
-      - noActivitySince:
-          days: 3
-      actions:
-      - closeIssue
-    - description: 
-      frequencies:
-      - hourly:
-          hour: 6
-      filters:
-      - isIssue
-      - isOpen
-      - hasLabel:
-          label: 'Needs: Author Feedback'
-      - noActivitySince:
-          days: 4
-      - isNotLabeledWith:
-          label: no-recent-activity
-      actions:
-      - addLabel:
-          label: no-recent-activity
-      - addReply:
-          reply: This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**. It will be closed if no further activity occurs **within 3 days of this comment**.
-    - description: 
-      frequencies:
-      - hourly:
-          hour: 6
-      filters:
-      - isIssue
-      - isOpen
-      - hasLabel:
-          label: duplicate
-      - noActivitySince:
-          days: 1
-      actions:
-      - addReply:
-          reply: This issue has been marked as duplicate and has not had any activity for **1 day**. It will be closed for housekeeping purposes.
-      - closeIssue
+      - description:
+        frequencies:
+          - hourly:
+              hour: 3
+        filters:
+          - isIssue
+          - isOpen
+          - hasLabel:
+              label: "Needs: Author Feedback"
+          - hasLabel:
+              label: no-recent-activity
+          - noActivitySince:
+              days: 3
+        actions:
+          - closeIssue
+      - description:
+        frequencies:
+          - hourly:
+              hour: 3
+        filters:
+          - isIssue
+          - isOpen
+          - hasLabel:
+              label: "Needs: Author Feedback"
+          - noActivitySince:
+              days: 4
+          - isNotLabeledWith:
+              label: no-recent-activity
+        actions:
+          - addLabel:
+              label: no-recent-activity
+          - addReply:
+              reply: This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**. It will be closed if no further activity occurs **within 3 days of this comment**.
+      - description:
+        frequencies:
+          - hourly:
+              hour: 3
+        filters:
+          - isIssue
+          - isOpen
+          - hasLabel:
+              label: duplicate
+          - noActivitySince:
+              days: 1
+        actions:
+          - addReply:
+              reply: This issue has been marked as duplicate and has not had any activity for **1 day**. It will be closed for housekeeping purposes.
+          - closeIssue
     eventResponderTasks:
-    - if:
-      - payloadType: Issue_Comment
-      - isAction:
-          action: Created
-      - isActivitySender:
-          issueAuthor: True
-      - hasLabel:
-          label: 'Needs: Author Feedback'
-      then:
-      - addLabel:
-          label: 'Needs: Attention :wave:'
-      - removeLabel:
-          label: 'Needs: Author Feedback'
-      description: 
-    - if:
-      - payloadType: Issues
-      - not:
-          isAction:
-            action: Closed
-      - hasLabel:
-          label: no-recent-activity
-      then:
-      - removeLabel:
-          label: no-recent-activity
-      description: 
-    - if:
-      - payloadType: Issue_Comment
-      - hasLabel:
-          label: no-recent-activity
-      then:
-      - removeLabel:
-          label: no-recent-activity
-      description: 
-onFailure: 
-onSuccess: 
+      - if:
+          - payloadType: Issues
+          - and:
+              - isOpen
+              - not:
+                  and:
+                    - isAssignedToSomeone
+                    - isLabeled
+        then:
+          - addLabel:
+              label: "Needs: Triage :mag:"
+      - if:
+          - payloadType: Issue_Comment
+          - isAction:
+              action: Created
+          - isActivitySender:
+              issueAuthor: True
+          - hasLabel:
+              label: "Needs: Author Feedback"
+        then:
+          - addLabel:
+              label: "Needs: Attention :wave:"
+          - removeLabel:
+              label: "Needs: Author Feedback"
+        description:
+      - if:
+          - payloadType: Issues
+          - not:
+              isAction:
+                action: Closed
+          - hasLabel:
+              label: no-recent-activity
+        then:
+          - removeLabel:
+              label: no-recent-activity
+        description:
+      - if:
+          - payloadType: Issue_Comment
+          - hasLabel:
+              label: no-recent-activity
+        then:
+          - removeLabel:
+              label: no-recent-activity
+        description:
+onFailure:
+onSuccess:


### PR DESCRIPTION
This PR fixes our GH automation so that new issues have the "needs: triage" label added automatically again. This stopped working recently when FabricBot migrated to a new config language