### PR TITLE
Update durablefunctionsmonitor.dotnetbackend.csproj for Azure.Identity vulnerability

### DIFF
--- a/durablefunctionsmonitor.dotnetbackend/durablefunctionsmonitor.dotnetbackend.csproj
+++ b/durablefunctionsmonitor.dotnetbackend/durablefunctionsmonitor.dotnetbackend.csproj
@@ -9,7 +9,7 @@
 
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.9.6" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.12.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.10.2" />
     <PackageReference Include="Fluid.Core" Version="2.1.4" />


### PR DESCRIPTION
To fix vulnerability CVE-2023-36414, the Azure.Identity package needs to be upgraded to version >= 1.10.2. This is a transitive dependency of the Microsoft.Azure.WebJobs.Extensions.DurableTask package. So to mitigate this, the package version has been upgraded to the latest one.