### PR TITLE
#161, fixing server-directed auth for Isolated with ASP.Net Core Integration

### DIFF
--- a/durablefunctionsmonitor.dotnetisolated.core/Common/Auth.cs
+++ b/durablefunctionsmonitor.dotnetisolated.core/Common/Auth.cs
@@ -329,7 +329,7 @@ namespace DurableFunctionsMonitor.DotNetIsolated
             // First trying the request object
             var principal = new ClaimsPrincipal(request.Identities);
 
-            if (principal.Identity.IsAuthenticated && principal.HasClaim(c => c.Type == userNameClaimName))
+            if (principal.Identity != null && principal.Identity.IsAuthenticated && principal.HasClaim(c => c.Type == userNameClaimName))
             {
                 return principal;
             }

--- a/durablefunctionsmonitor.dotnetisolated.core/Common/Auth.cs
+++ b/durablefunctionsmonitor.dotnetisolated.core/Common/Auth.cs
@@ -346,6 +346,7 @@ namespace DurableFunctionsMonitor.DotNetIsolated
             return await ValidateToken(authHeaderValues?.SingleOrDefault());
         }
 
+        // parsing header directly as per the guidance here: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger?tabs=python-v2%2Cisolated-process%2Cnodejs-v4%2Cfunctionsv2&pivots=programming-language-csharp#working-with-client-identities
         private  static ClaimsPrincipal ParseMsClientPrincipalHeader(string headerValue, DfmSettings settings)
         {
             // First need to make sure Easy Auth is in effect. Otherwise we must never trust the x-ms-client-principal header.

--- a/durablefunctionsmonitor.dotnetisolated/.vscode/settings.json
+++ b/durablefunctionsmonitor.dotnetisolated/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "azureFunctions.deploySubpath": "bin/Release/net7.0/publish",
+    "azureFunctions.deploySubpath": "bin/Release/net8.0/publish",
     "azureFunctions.projectLanguage": "C#",
     "azureFunctions.projectRuntime": "~4",
     "debug.internalConsoleOptions": "neverOpen",

--- a/durablefunctionsmonitor.dotnetisolated/.vscode/tasks.json
+++ b/durablefunctionsmonitor.dotnetisolated/.vscode/tasks.json
@@ -59,7 +59,7 @@
 			"type": "func",
 			"dependsOn": "build (functions)",
 			"options": {
-				"cwd": "${workspaceFolder}/bin/Debug/net7.0"
+				"cwd": "${workspaceFolder}/bin/Debug/net8.0"
 			},
 			"command": "host start",
 			"isBackground": true,

--- a/tests/durablefunctionsmonitor.dotnetisolated.core.tests/AuthTests.cs
+++ b/tests/durablefunctionsmonitor.dotnetisolated.core.tests/AuthTests.cs
@@ -243,7 +243,7 @@ namespace durablefunctionsmonitor.dotnetbackend.tests
 
             request.AddIdentity(new ClaimsIdentity(new Claim[] {
                 new Claim("preferred_username", userName)
-            }));
+            }, "tino-test-auth-type"));
 
             // Act
             var task = Auth.ValidateIdentityAsync(request, OperationKind.Read, new DfmSettings(), new DfmExtensionPoints());
@@ -275,7 +275,7 @@ namespace durablefunctionsmonitor.dotnetbackend.tests
 
             request.AddIdentity(new ClaimsIdentity(new Claim[] {
                 new Claim("preferred_username", userName)
-            }));
+            }, "tino-test-auth-type"));
 
             // Act
 
@@ -311,7 +311,7 @@ namespace durablefunctionsmonitor.dotnetbackend.tests
 
             request.AddIdentity(new ClaimsIdentity(new Claim[] {
                 new Claim("preferred_username", userName)
-            }));
+            }, "tino-test-auth-type"));
 
             // Act
 
@@ -344,10 +344,12 @@ namespace durablefunctionsmonitor.dotnetbackend.tests
             Environment.SetEnvironmentVariable(EnvVariableNames.DFM_ALLOWED_APP_ROLES, "role1,role2");
             Environment.SetEnvironmentVariable(EnvVariableNames.DFM_ALLOWED_READ_ONLY_APP_ROLES, string.Empty);
 
-            request.AddIdentity(new ClaimsIdentity(new Claim[] {
+            var identity = new ClaimsIdentity(new Claim[] {
                 new Claim("preferred_username", userName),
                 new Claim("roles", "role1")
-            }));
+            }, "tino-test-auth-type");
+
+            request.AddIdentity(identity);
 
             // Act
 
@@ -379,7 +381,7 @@ namespace durablefunctionsmonitor.dotnetbackend.tests
             request.AddIdentity(new ClaimsIdentity(new Claim[] {
                 new Claim("preferred_username", userName),
                 new Claim("roles", "readonly_role1")
-            }));
+            }, "tino-test-auth-type"));
 
             // Act
 
@@ -413,7 +415,7 @@ namespace durablefunctionsmonitor.dotnetbackend.tests
             var principal = new ClaimsPrincipal(new ClaimsIdentity[] { new ClaimsIdentity( new Claim[] {
                 new Claim("preferred_username", userName),
                 new Claim("roles", roleName)
-            })});
+            }, "tino-test-auth-type")});
 
             ICollection<SecurityKey> securityKeys = new SecurityKey[0];
 


### PR DESCRIPTION
[As discovered](https://github.com/microsoft/DurableFunctionsMonitor/issues/161#issuecomment-2137759957), when using server-directed EasyAuth and ASP.Net Core Integration, the user identity is missing from HttpRequestData.Identities.

So we'll have to parse and use the "x-ms-client-principal" header on our own.