### PR TITLE
Update README.md to reflect currently supported .net version

### DIFF
--- a/durablefunctionsmonitor.dotnetisolated.core/README.md
+++ b/durablefunctionsmonitor.dotnetisolated.core/README.md
@@ -1,6 +1,6 @@
 # DurableFunctionsMonitor.DotNetIsolated.Core
 
-An incarnation of DurableFunctionsMonitor that can be "injected" into your [.NET 7 Isolated](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide) Azure Function.
+An incarnation of DurableFunctionsMonitor that can be "injected" into your [.NET 8 Isolated](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide) Azure Function.
 
 ## How to use
 


### PR DESCRIPTION
Change link text from .net 7 to .net 8, as it is the currently referenced version in the doc that is referenced, and the current version of durablefunctionsmonitor.dotnetisolated (6.5) is indicated to support .net 8