### PR TITLE
Implement full access app role

### DIFF
--- a/durablefunctionsmonitor.dotnetbackend/Common/Globals.cs
+++ b/durablefunctionsmonitor.dotnetbackend/Common/Globals.cs
@@ -32,6 +32,7 @@ namespace DurableFunctionsMonitor.DotNetBackend
         public const string WEBSITE_AUTH_UNAUTHENTICATED_ACTION = "WEBSITE_AUTH_UNAUTHENTICATED_ACTION";
         public const string DFM_ALLOWED_USER_NAMES = "DFM_ALLOWED_USER_NAMES";
         public const string DFM_ALLOWED_APP_ROLES = "DFM_ALLOWED_APP_ROLES";
+        public const string DFM_ALLOWED_FULL_ACCESS_APP_ROLES = "DFM_ALLOWED_FULL_ACCESS_APP_ROLES";
         public const string DFM_ALLOWED_READ_ONLY_APP_ROLES = "DFM_ALLOWED_READ_ONLY_APP_ROLES";
         public const string DFM_HUB_NAME = "DFM_HUB_NAME";
         public const string DFM_NONCE = "DFM_NONCE";

--- a/durablefunctionsmonitor.dotnetbackend/Common/Setup.cs
+++ b/durablefunctionsmonitor.dotnetbackend/Common/Setup.cs
@@ -47,6 +47,13 @@ namespace DurableFunctionsMonitor.DotNetBackend
         public IEnumerable<string> AllowedAppRoles { get; set; }
 
         /// <summary>
+        /// List of App Roles, that are allowed to full access DurableFunctionsMonitor endpoint. Users/Groups then need
+        /// to be assigned one of these roles via AAD Enterprise Applications->[your AAD app]->Users and Groups tab.
+        /// Once set, the incoming access token is expected to contain one of these in its 'roles' claim.
+        /// </summary>
+        public IEnumerable<string> AllowedFullAccessAppRoles { get; set; }
+
+        /// <summary>
         /// List of App Roles, that are allowed read only access to the DurableFunctionsMonitor endpoint. Users/Groups then need 
         /// to be assigned one of these roles via AAD Enterprise Applications->[your AAD app]->Users and Groups tab.
         /// Once set, the incoming access token is expected to contain one of these in its 'roles' claim.
@@ -142,20 +149,20 @@ namespace DurableFunctionsMonitor.DotNetBackend
             {
                 string dfmAllowedUserNames = Environment.GetEnvironmentVariable(EnvVariableNames.DFM_ALLOWED_USER_NAMES);
                 string dfmAllowedAppRoles = Environment.GetEnvironmentVariable(EnvVariableNames.DFM_ALLOWED_APP_ROLES);
-                string dfmAllowedreadOnlyAppRoles = Environment.GetEnvironmentVariable(EnvVariableNames.DFM_ALLOWED_READ_ONLY_APP_ROLES);
+                string dfmAllowedFullAccessAppRoles = Environment.GetEnvironmentVariable(EnvVariableNames.DFM_ALLOWED_FULL_ACCESS_APP_ROLES);
+                string dfmAllowedReadOnlyAppRoles = Environment.GetEnvironmentVariable(EnvVariableNames.DFM_ALLOWED_READ_ONLY_APP_ROLES);
                 string dfmMode = Environment.GetEnvironmentVariable(EnvVariableNames.DFM_MODE);
                 string dfmUserNameClaimName = Environment.GetEnvironmentVariable(EnvVariableNames.DFM_USERNAME_CLAIM_NAME);
                 string dfmRolesClaimName = Environment.GetEnvironmentVariable(EnvVariableNames.DFM_ROLES_CLAIM_NAME);
 
                 var allowedAppRoles = dfmAllowedAppRoles == null ? null : dfmAllowedAppRoles.Split(',');
-                var allowedReadOnlyAppRoles = dfmAllowedreadOnlyAppRoles == null ? null : dfmAllowedreadOnlyAppRoles.Split(',');
-                if (allowedAppRoles != null && allowedReadOnlyAppRoles != null)
+                var allowedFullAccessAppRoles = dfmAllowedFullAccessAppRoles == null ? null : dfmAllowedFullAccessAppRoles.Split(',');
+                var allowedReadOnlyAppRoles = dfmAllowedReadOnlyAppRoles == null ? null : dfmAllowedReadOnlyAppRoles.Split(',');
+
+                // Validating that same app role does not appear in multiple settings
+                if (AreAppRoleListsIntersecting(allowedAppRoles, allowedFullAccessAppRoles, allowedReadOnlyAppRoles))
                 {
-                    // Validating that same app role does not appear in both settings
-                    if (allowedAppRoles.Intersect(allowedReadOnlyAppRoles).Any())
-                    {
-                        throw new NotSupportedException($"{EnvVariableNames.DFM_ALLOWED_APP_ROLES} and {EnvVariableNames.DFM_ALLOWED_READ_ONLY_APP_ROLES} should not intersect");
-                    }
+                    throw new NotSupportedException($"{EnvVariableNames.DFM_ALLOWED_APP_ROLES}, {EnvVariableNames.DFM_ALLOWED_FULL_ACCESS_APP_ROLES} and {EnvVariableNames.DFM_ALLOWED_READ_ONLY_APP_ROLES} should not intersect");
                 }
 
                 _settings = new DfmSettings()
@@ -166,6 +173,7 @@ namespace DurableFunctionsMonitor.DotNetBackend
                     Mode = dfmMode == DfmMode.ReadOnly.ToString() ? DfmMode.ReadOnly : DfmMode.Normal,
                     AllowedUserNames = dfmAllowedUserNames == null ? null : dfmAllowedUserNames.Split(','),
                     AllowedAppRoles = allowedAppRoles,
+                    AllowedFullAccessAppRoles = allowedFullAccessAppRoles,
                     AllowedReadOnlyAppRoles = allowedReadOnlyAppRoles,
                     UserNameClaimName = string.IsNullOrEmpty(dfmUserNameClaimName) ? Auth.PreferredUserNameClaim : dfmUserNameClaimName,
                     RolesClaimName = string.IsNullOrEmpty(dfmRolesClaimName) ? Auth.RolesClaim : dfmRolesClaimName
@@ -274,6 +282,24 @@ namespace DurableFunctionsMonitor.DotNetBackend
         {
             var version = typeof(DfmEndpoint).Assembly.GetName().Version;
             return $"{version.Major}.{version.Minor}.{version.Build}";
+        }
+
+        private static bool AreAppRoleListsIntersecting(params string[][] appRoleLists)
+        {
+            HashSet<string> distinctAppRoles = new HashSet<string>();
+            int totalNumberOfAppRoles = 0;
+
+            for (int i = 0; i < appRoleLists.Length; i++)
+            {
+                if (appRoleLists[i] != null)
+                {
+                    distinctAppRoles.UnionWith(appRoleLists[i]);
+                    totalNumberOfAppRoles += appRoleLists[i].Length;
+                }
+
+            }
+
+            return distinctAppRoles.Count != totalNumberOfAppRoles;
         }
     }
 }

--- a/durablefunctionsmonitor.dotnetisolated.core/Common/Auth.cs
+++ b/durablefunctionsmonitor.dotnetisolated.core/Common/Auth.cs
@@ -135,19 +135,25 @@ namespace DurableFunctionsMonitor.DotNetIsolated
 
             // Also validating App Roles, but only if any of relevant setting is set
             var allowedAppRoles = settings.AllowedAppRoles;
+            var allowedFullAccessAppRoles = settings.AllowedFullAccessAppRoles;
             var allowedReadOnlyAppRoles = settings.AllowedReadOnlyAppRoles;
 
-            if (allowedAppRoles != null || allowedReadOnlyAppRoles != null)
+            if (allowedAppRoles != null || allowedFullAccessAppRoles != null || allowedReadOnlyAppRoles != null)
             {
                 var roleClaims = principal.FindAll(settings.RolesClaimName);
 
-                bool userIsInAppRole = roleClaims.Any(claim => allowedAppRoles != null && allowedAppRoles.Contains(claim.Value));
-                bool userIsInReadonlyRole = roleClaims.Any(claim => allowedReadOnlyAppRoles != null && allowedReadOnlyAppRoles.Contains(claim.Value));
+                bool userIsInAppRole = allowedAppRoles != null && roleClaims.Any(claim => allowedAppRoles.Contains(claim.Value));
+                bool userIsInFullAccessRole = allowedFullAccessAppRoles != null && roleClaims.Any(claim => allowedFullAccessAppRoles.Contains(claim.Value));
+                bool userIsInReadonlyRole =  allowedReadOnlyAppRoles != null && roleClaims.Any(claim =>allowedReadOnlyAppRoles.Contains(claim.Value));
 
                 // If user belongs _neither_ to AllowedAppRoles _nor_ to AllowedReadOnlyAppRoles
-                if (!(userIsInAppRole || userIsInReadonlyRole))
+                if (!(userIsInAppRole || userIsInFullAccessRole || userIsInReadonlyRole))
                 {
-                    throw new DfmUnauthorizedException($"User {userNameClaim.Value} doesn't have any of roles mentioned in {EnvVariableNames.DFM_ALLOWED_APP_ROLES} or {EnvVariableNames.DFM_ALLOWED_READ_ONLY_APP_ROLES} config setting. Call is rejected");
+                    throw new DfmUnauthorizedException($"User {userNameClaim.Value} doesn't have any of roles mentioned in {EnvVariableNames.DFM_ALLOWED_APP_ROLES}, {EnvVariableNames.DFM_ALLOWED_FULL_ACCESS_APP_ROLES} or {EnvVariableNames.DFM_ALLOWED_READ_ONLY_APP_ROLES} config setting. Call is rejected");
+                }
+
+                if (userIsInFullAccessRole) {
+                    return settings.Mode;
                 }
 
                 // If current operation modifies any data, then validating that user is _not_ in ReadOnly mode

--- a/durablefunctionsmonitor.dotnetisolated.core/Common/DfmSettings.cs
+++ b/durablefunctionsmonitor.dotnetisolated.core/Common/DfmSettings.cs
@@ -38,6 +38,13 @@ namespace DurableFunctionsMonitor.DotNetIsolated
         public IEnumerable<string> AllowedAppRoles { get; set; }
 
         /// <summary>
+        /// List of App Roles, that are allowed to full access DurableFunctionsMonitor endpoint. Users/Groups then need
+        /// to be assigned one of these roles via AAD Enterprise Applications->[your AAD app]->Users and Groups tab.
+        /// Once set, the incoming access token is expected to contain one of these in its 'roles' claim.
+        /// </summary>
+        public IEnumerable<string> AllowedFullAccessAppRoles { get; set; }
+
+        /// <summary>
         /// List of App Roles, that are allowed read only access to the DurableFunctionsMonitor endpoint. Users/Groups then need 
         /// to be assigned one of these roles via AAD Enterprise Applications->[your AAD app]->Users and Groups tab.
         /// Once set, the incoming access token is expected to contain one of these in its 'roles' claim.
@@ -87,29 +94,48 @@ namespace DurableFunctionsMonitor.DotNetIsolated
 
             string dfmAllowedUserNames = Environment.GetEnvironmentVariable(EnvVariableNames.DFM_ALLOWED_USER_NAMES);
             string dfmAllowedAppRoles = Environment.GetEnvironmentVariable(EnvVariableNames.DFM_ALLOWED_APP_ROLES);
-            string dfmAllowedreadOnlyAppRoles = Environment.GetEnvironmentVariable(EnvVariableNames.DFM_ALLOWED_READ_ONLY_APP_ROLES);
+            string dfmAllowedFullAccessAppRoles = Environment.GetEnvironmentVariable(EnvVariableNames.DFM_ALLOWED_FULL_ACCESS_APP_ROLES);
+            string dfmAllowedReadOnlyAppRoles = Environment.GetEnvironmentVariable(EnvVariableNames.DFM_ALLOWED_READ_ONLY_APP_ROLES);
             string dfmMode = Environment.GetEnvironmentVariable(EnvVariableNames.DFM_MODE);
             string dfmUserNameClaimName = Environment.GetEnvironmentVariable(EnvVariableNames.DFM_USERNAME_CLAIM_NAME);
             string dfmRolesClaimName = Environment.GetEnvironmentVariable(EnvVariableNames.DFM_ROLES_CLAIM_NAME);
 
             var allowedAppRoles = dfmAllowedAppRoles == null ? null : dfmAllowedAppRoles.Split(',');
-            var allowedReadOnlyAppRoles = dfmAllowedreadOnlyAppRoles == null ? null : dfmAllowedreadOnlyAppRoles.Split(',');
-            if (allowedAppRoles != null && allowedReadOnlyAppRoles != null)
+            var allowedFullAccessAppRoles = dfmAllowedFullAccessAppRoles == null ? null : dfmAllowedFullAccessAppRoles.Split(',');
+            var allowedReadOnlyAppRoles = dfmAllowedReadOnlyAppRoles == null ? null : dfmAllowedReadOnlyAppRoles.Split(',');
+
+            // Validating that same app role does not appear in multiple settings
+            if (AreAppRoleListsIntersecting(allowedAppRoles, allowedFullAccessAppRoles, allowedReadOnlyAppRoles))
             {
-                // Validating that same app role does not appear in both settings
-                if (allowedAppRoles.Intersect(allowedReadOnlyAppRoles).Any())
-                {
-                    throw new NotSupportedException($"{EnvVariableNames.DFM_ALLOWED_APP_ROLES} and {EnvVariableNames.DFM_ALLOWED_READ_ONLY_APP_ROLES} should not intersect");
-                }
+                throw new NotSupportedException($"{EnvVariableNames.DFM_ALLOWED_APP_ROLES}, {EnvVariableNames.DFM_ALLOWED_FULL_ACCESS_APP_ROLES} and {EnvVariableNames.DFM_ALLOWED_READ_ONLY_APP_ROLES} should not intersect");
             }
 
             this.DisableAuthentication = dfmNonce == Auth.ISureKnowWhatIAmDoingNonce;
             this.Mode = dfmMode == DfmMode.ReadOnly.ToString() ? DfmMode.ReadOnly : DfmMode.Normal;
             this.AllowedUserNames = dfmAllowedUserNames == null ? null : dfmAllowedUserNames.Split(',');
             this.AllowedAppRoles = allowedAppRoles;
+            this.AllowedFullAccessAppRoles = allowedFullAccessAppRoles;
             this.AllowedReadOnlyAppRoles = allowedReadOnlyAppRoles;
             this.UserNameClaimName = string.IsNullOrEmpty(dfmUserNameClaimName) ? Auth.PreferredUserNameClaim : dfmUserNameClaimName;
             this.RolesClaimName = string.IsNullOrEmpty(dfmRolesClaimName) ? Auth.RolesClaim : dfmRolesClaimName;
+        }
+
+        private static bool AreAppRoleListsIntersecting(params string[][] appRoleLists)
+        {
+            HashSet<string> distinctAppRoles = new HashSet<string>();
+            int totalNumberOfAppRoles = 0;
+
+            for (int i = 0; i < appRoleLists.Length; i++)
+            {
+                if (appRoleLists[i] != null)
+                {
+                    distinctAppRoles.UnionWith(appRoleLists[i]);
+                    totalNumberOfAppRoles += appRoleLists[i].Length;
+                }
+
+            }
+
+            return distinctAppRoles.Count != totalNumberOfAppRoles;
         }
     }
 }

--- a/durablefunctionsmonitor.dotnetisolated.core/Common/Globals.cs
+++ b/durablefunctionsmonitor.dotnetisolated.core/Common/Globals.cs
@@ -27,6 +27,7 @@ namespace DurableFunctionsMonitor.DotNetIsolated
         public const string WEBSITE_AUTH_UNAUTHENTICATED_ACTION = "WEBSITE_AUTH_UNAUTHENTICATED_ACTION";
         public const string DFM_ALLOWED_USER_NAMES = "DFM_ALLOWED_USER_NAMES";
         public const string DFM_ALLOWED_APP_ROLES = "DFM_ALLOWED_APP_ROLES";
+        public const string DFM_ALLOWED_FULL_ACCESS_APP_ROLES = "DFM_ALLOWED_FULL_ACCESS_APP_ROLES";
         public const string DFM_ALLOWED_READ_ONLY_APP_ROLES = "DFM_ALLOWED_READ_ONLY_APP_ROLES";
         public const string DFM_HUB_NAME = "DFM_HUB_NAME";
         public const string DFM_NONCE = "DFM_NONCE";

--- a/tests/durablefunctionsmonitor.dotnetbackend.tests/SetupTests.cs
+++ b/tests/durablefunctionsmonitor.dotnetbackend.tests/SetupTests.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Extensions.Logging;
+using DurableFunctionsMonitor.DotNetBackend;
+using System.Threading.Tasks;
+using Moq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using System;
+
+namespace durablefunctionsmonitor.dotnetbackend.tests
+{
+    [TestClass]
+    public class SetupTests
+    {
+        [TestMethod]
+        public void ThrowErrorIfAppRolesOverlapInConfiguration()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable(EnvVariableNames.DFM_HUB_NAME, string.Empty);
+            Environment.SetEnvironmentVariable(EnvVariableNames.DFM_ALLOWED_USER_NAMES, "");
+            Environment.SetEnvironmentVariable(EnvVariableNames.DFM_ALLOWED_APP_ROLES, "role1,role2");
+            Environment.SetEnvironmentVariable(EnvVariableNames.DFM_ALLOWED_FULL_ACCESS_APP_ROLES, "role2");
+            Environment.SetEnvironmentVariable(EnvVariableNames.DFM_ALLOWED_READ_ONLY_APP_ROLES, "");
+
+            // Act & Assert
+            Assert.ThrowsException<System.NotSupportedException>(() => {
+                DfmEndpoint.Setup();
+            });
+        }
+    }
+}

--- a/tests/durablefunctionsmonitor.dotnetisolated.core.tests/SetupTests.cs
+++ b/tests/durablefunctionsmonitor.dotnetisolated.core.tests/SetupTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Extensions.Logging;
+using DurableFunctionsMonitor.DotNetIsolated;
+using System.Threading.Tasks;
+using Moq;
+using System;
+
+namespace durablefunctionsmonitor.dotnetbackend.tests
+{
+    [TestClass]
+    public class SetupTests
+    {
+        [TestMethod]
+        public void ThrowErrorIfAppRolesOverlapInConfiguration()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable(EnvVariableNames.DFM_HUB_NAME, string.Empty);
+            Environment.SetEnvironmentVariable(EnvVariableNames.DFM_ALLOWED_USER_NAMES, "");
+            Environment.SetEnvironmentVariable(EnvVariableNames.DFM_ALLOWED_APP_ROLES, "role1,role2");
+            Environment.SetEnvironmentVariable(EnvVariableNames.DFM_ALLOWED_FULL_ACCESS_APP_ROLES, "role2");
+            Environment.SetEnvironmentVariable(EnvVariableNames.DFM_ALLOWED_READ_ONLY_APP_ROLES, "");
+
+            // Act & Assert
+            Assert.ThrowsException<System.NotSupportedException>(() => {
+                new DfmSettings();
+            });
+        }
+    }
+}


### PR DESCRIPTION
This pull request addresses the issue discussed in https://github.com/microsoft/DurableFunctionsMonitor/issues/221.

I have implemented a new configuration setting called `DFM_ALLOWED_FULL_ACCESS_APP_ROLES`. If a user has an app role listed in `DFM_ALLOWED_FULL_ACCESS_APP_ROLES`, then the user gets full access to the DFM, regardless of their other roles.