### PR TITLE
[two bugs away] checking for invalid symbols in path

### DIFF
--- a/durablefunctionsmonitor.dotnetbackend/Common/Auth.cs
+++ b/durablefunctionsmonitor.dotnetbackend/Common/Auth.cs
@@ -7,10 +7,10 @@ using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Security.Claims;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using System.Web;
 using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -243,6 +243,20 @@ namespace DurableFunctionsMonitor.DotNetBackend
             if (!ValidTaskHubNameRegex.Match(hubName).Success)
             {
                 throw new ArgumentException($"Task Hub name is invalid.");
+            }
+        }
+
+        // Checks that a path does not look malicious
+        public static void ThrowIfPathHasInvalidSymbols(string path)
+        {
+            if (!string.IsNullOrEmpty(path))
+            {
+                string invalidSymbols = "{}()<>:;=";
+
+                if (invalidSymbols.Any(path.Contains) || invalidSymbols.Any(HttpUtility.UrlDecode(path).Contains))
+                {
+                    throw new ArgumentException($"Path contains invalid characters.");
+                }
             }
         }
 

--- a/durablefunctionsmonitor.dotnetbackend/Functions/ServeStatics.cs
+++ b/durablefunctionsmonitor.dotnetbackend/Functions/ServeStatics.cs
@@ -162,6 +162,8 @@ namespace DurableFunctionsMonitor.DotNetBackend
                     routePrefix = requestPath.Substring(0, pos);
                 }
             }
+            // Two bugs away. Checking that route prefix does not look malicious.
+            Auth.ThrowIfPathHasInvalidSymbols(routePrefix);
 
             routePrefix = routePrefix?.Trim('/');
 

--- a/durablefunctionsmonitor.dotnetisolated.core/Common/Auth.cs
+++ b/durablefunctionsmonitor.dotnetisolated.core/Common/Auth.cs
@@ -6,6 +6,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Web;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -241,6 +242,20 @@ namespace DurableFunctionsMonitor.DotNetIsolated
             if (!ValidTaskHubNameRegex.Match(hubName).Success)
             {
                 throw new DfmUnauthorizedException($"Task Hub name is invalid.");
+            }
+        }
+
+        // Checks that a path does not look malicious
+        public static void ThrowIfPathHasInvalidSymbols(string path)
+        {
+            if (!string.IsNullOrEmpty(path))
+            {
+                string invalidSymbols = "{}()<>:;=";
+
+                if (invalidSymbols.Any(path.Contains) || invalidSymbols.Any(HttpUtility.UrlDecode(path).Contains))
+                {
+                    throw new DfmUnauthorizedException($"Path contains invalid characters.");
+                }
             }
         }
 

--- a/durablefunctionsmonitor.dotnetisolated.core/Functions/ServeStatics.cs
+++ b/durablefunctionsmonitor.dotnetisolated.core/Functions/ServeStatics.cs
@@ -167,6 +167,9 @@ namespace DurableFunctionsMonitor.DotNetIsolated
                 }
             }
 
+            // Two bugs away. Checking that route prefix does not look malicious.
+            Auth.ThrowIfPathHasInvalidSymbols(routePrefix);
+
             routePrefix = routePrefix?.Trim('/');
 
             // Prepending ingress route prefix, if configured


### PR DESCRIPTION
[It is already checked by this](https://github.com/microsoft/DurableFunctionsMonitor/blob/9a58cafb7950832f2845d47abd673f0c5e530dfa/durablefunctionsmonitor.dotnetbackend/Functions/ServeStatics.cs#L124), but just addressing security alert.